### PR TITLE
Removed WordPress core ("johnpbloch/wordpress": "^4.7.3")

### DIFF
--- a/site/CHANGELOG.md
+++ b/site/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.6: 2017-0325
+
+* Removed WordPress core ("johnpbloch/wordpress": "^4.7.3") to address issue. Ref: https://discourse.roots.io/t/johnpbloch-wordpress-moved-to-a-new-configuration-and-wp-goes-missing/9124/18
+
 ### 1.7.3: 2016-12-06
 
 * Update to WordPress 4.7

--- a/site/composer.json
+++ b/site/composer.json
@@ -92,7 +92,7 @@
     "php": ">=5.6",
     "composer/installers": "~1.0.12",
     "vlucas/phpdotenv": "^2.0.1",
-    "johnpbloch/wordpress": "4.7.2",
+    "johnpbloch/wordpress": "^4.7.3",
     "oscarotero/env": "^1.0",
     "roots/wp-password-bcrypt": "1.0.0",
     "wpackagist-plugin/better-wp-security": "^5.7.0",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c022858cdcbdf8fe31aa000d0564e96e",
+    "content-hash": "b669c86be75912e3d138bb4fc3d66ffa",
     "packages": [
         {
             "name": "composer/installers",
@@ -107,93 +107,8 @@
             "time": "2016-04-13T19:46:30+00:00"
         },
         {
-            "name": "johnpbloch/wordpress",
-            "version": "4.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "ac7b1792641d1fb61cb2901db292903b31694057"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/ac7b1792641d1fb61cb2901db292903b31694057",
-                "reference": "ac7b1792641d1fb61cb2901db292903b31694057",
-                "shasum": ""
-            },
-            "require": {
-                "johnpbloch/wordpress-core-installer": "~0.2",
-                "php": ">=5.3.2"
-            },
-            "type": "wordpress-core",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "WordPress Community",
-                    "homepage": "http://wordpress.org/about/"
-                }
-            ],
-            "description": "WordPress is web software you can use to create a beautiful website or blog.",
-            "homepage": "http://wordpress.org/",
-            "keywords": [
-                "blog",
-                "cms"
-            ],
-            "time": "2017-01-26T18:32:19+00:00"
-        },
-        {
-            "name": "johnpbloch/wordpress-core-installer",
-            "version": "0.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/johnpbloch/wordpress-core-installer.git",
-                "reference": "a04c2c383ef13aae077f36799ed2eafdebd618d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core-installer/zipball/a04c2c383ef13aae077f36799ed2eafdebd618d2",
-                "reference": "a04c2c383ef13aae077f36799ed2eafdebd618d2",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0"
-            },
-            "conflict": {
-                "composer/installers": "<1.0.6"
-            },
-            "require-dev": {
-                "composer/composer": "1.0.*@dev"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "johnpbloch\\Composer\\WordPressCorePlugin"
-            },
-            "autoload": {
-                "psr-0": {
-                    "johnpbloch\\Composer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "John P. Bloch",
-                    "email": "me@johnpbloch.com"
-                }
-            ],
-            "description": "A custom installer to handle deploying WordPress with composer",
-            "keywords": [
-                "wordpress"
-            ],
-            "time": "2015-06-11T15:15:30+00:00"
-        },
-        {
             "name": "misfist/advanced-custom-fields",
-            "version": "v5.5.7",
+            "version": "v5.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/misfist/advanced-custom-fields.git",
@@ -209,7 +124,7 @@
         },
         {
             "name": "misfist/tni",
-            "version": "v0.3.01",
+            "version": "v0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/misfist/tni-theme.git",
@@ -225,7 +140,7 @@
         },
         {
             "name": "misfist/tni-core-functionality",
-            "version": "v1.0.5.1",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/misfist/tni-core-functionality.git",
@@ -410,15 +325,15 @@
         },
         {
             "name": "wpackagist-plugin/caldera-forms",
-            "version": "1.5.0.2",
+            "version": "1.5.0.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/caldera-forms/",
-                "reference": "tags/1.5.0.2"
+                "reference": "tags/1.5.0.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/caldera-forms.1.5.0.2.zip",
+                "url": "https://downloads.wordpress.org/plugin/caldera-forms.1.5.0.6.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -430,15 +345,15 @@
         },
         {
             "name": "wpackagist-plugin/delete-comments-by-status",
-            "version": "1.5.1",
+            "version": "1.5.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/delete-comments-by-status/",
-                "reference": "tags/1.5.1"
+                "reference": "trunk"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/delete-comments-by-status.1.5.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/delete-comments-by-status.zip?timestamp=1488369549",
                 "reference": null,
                 "shasum": null
             },
@@ -447,26 +362,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/delete-comments-by-status/"
-        },
-        {
-            "name": "wpackagist-plugin/edit-flow",
-            "version": "0.8.2",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/edit-flow/",
-                "reference": "tags/0.8.2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/edit-flow.0.8.2.zip",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/edit-flow/"
         },
         {
             "name": "wpackagist-plugin/google-analytics-dashboard-for-wp",
@@ -490,15 +385,15 @@
         },
         {
             "name": "wpackagist-plugin/image-widget",
-            "version": "4.3",
+            "version": "4.3.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/image-widget/",
-                "reference": "tags/4.3"
+                "reference": "tags/4.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/image-widget.4.3.zip",
+                "url": "https://downloads.wordpress.org/plugin/image-widget.4.3.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -529,36 +424,16 @@
             "homepage": "https://wordpress.org/plugins/imsanity/"
         },
         {
-            "name": "wpackagist-plugin/intuitive-custom-post-order",
-            "version": "3.0.7",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/intuitive-custom-post-order/",
-                "reference": "tags/3.0.7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/intuitive-custom-post-order.3.0.7.zip",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/intuitive-custom-post-order/"
-        },
-        {
             "name": "wpackagist-plugin/jetpack",
-            "version": "4.6",
+            "version": "4.7.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/4.6"
+                "reference": "tags/4.7.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.4.6.zip",
+                "url": "https://downloads.wordpress.org/plugin/jetpack.4.7.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -590,15 +465,15 @@
         },
         {
             "name": "wpackagist-plugin/mailchimp-for-wp",
-            "version": "4.0.13",
+            "version": "4.1.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/mailchimp-for-wp/",
-                "reference": "tags/4.0.13"
+                "reference": "tags/4.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/mailchimp-for-wp.4.0.13.zip",
+                "url": "https://downloads.wordpress.org/plugin/mailchimp-for-wp.4.1.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -627,26 +502,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/metronet-profile-picture/"
-        },
-        {
-            "name": "wpackagist-plugin/multi-image-metabox",
-            "version": "1.3.5",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/multi-image-metabox/",
-                "reference": "trunk"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/multi-image-metabox.zip",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/multi-image-metabox/"
         },
         {
             "name": "wpackagist-plugin/post-type-archive-links",
@@ -689,6 +544,26 @@
             "homepage": "https://wordpress.org/plugins/w3-total-cache/"
         },
         {
+            "name": "wpackagist-plugin/widget-css-classes",
+            "version": "1.4.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/widget-css-classes/",
+                "reference": "tags/1.4.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/widget-css-classes.1.4.0.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/widget-css-classes/"
+        },
+        {
             "name": "wpackagist-plugin/wp-chosen",
             "version": "2.1.0",
             "source": {
@@ -710,15 +585,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-retina-2x",
-            "version": "4.7.7",
+            "version": "4.8.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-retina-2x/",
-                "reference": "tags/4.7.7"
+                "reference": "tags/4.8.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-retina-2x.4.7.7.zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-retina-2x.4.8.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -770,15 +645,15 @@
         },
         {
             "name": "wpackagist-theme/gridbox",
-            "version": "1.0.9",
+            "version": "1.2.1",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/gridbox/",
-                "reference": "1.0.9"
+                "reference": "1.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/gridbox.1.0.9.zip",
+                "url": "https://downloads.wordpress.org/theme/gridbox.1.2.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -792,16 +667,16 @@
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "86dd55a522238211f9f3631e3361703578941d9a"
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/86dd55a522238211f9f3631e3361703578941d9a",
-                "reference": "86dd55a522238211f9f3631e3361703578941d9a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
                 "shasum": ""
             },
             "require": {
@@ -866,7 +741,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-02-02T03:30:00+00:00"
+            "time": "2017-03-01T22:17:45+00:00"
         },
         {
             "name": "wpackagist-plugin/developer",


### PR DESCRIPTION
* Removed WordPress core ("johnpbloch/wordpress": "^4.7.3") to address issue. Ref: https://discourse.roots.io/t/johnpbloch-wordpress-moved-to-a-new-configuration-and-wp-goes-missing/9124/18